### PR TITLE
Fix: Deletion Resurrection Bug

### DIFF
--- a/sync/SyncManager.ts
+++ b/sync/SyncManager.ts
@@ -366,18 +366,16 @@ export class SyncManager {
 			if (localFile && !(localFile instanceof TFolder)) {
 				await this.app.vault.delete(localFile);
 			}
-			// Update state map: file deleted locally, clear localMtime
-			const currentState = stateFiles.get(decision.filePath) || {};
+			// Update state map: file deleted locally AND it was already gone from remote
 			stateFiles.set(decision.filePath, {
 				localMtime: undefined,
-				remoteMtime: currentState.remoteMtime,
+				remoteMtime: undefined,
 			});
 		} else if (decision.action === SyncAction.DELETE_REMOTE) {
 			await this.s3Service.deleteRemoteFile(decision.filePath);
-			// Update state map: file deleted remotely, clear remoteMtime
-			const currentState = stateFiles.get(decision.filePath) || {};
+			// Update state map: file deleted remotely AND it was already gone from local
 			stateFiles.set(decision.filePath, {
-				localMtime: currentState.localMtime,
+				localMtime: undefined,
 				remoteMtime: undefined,
 			});
 		}
@@ -487,20 +485,10 @@ export class SyncManager {
 		const newState: SyncState = {};
 		
 		for (const [filePath, fileState] of stateFiles.entries()) {
-			// For robustness: Remove entries where only one timestamp is defined 
-			// (incomplete state that can cause race conditions). This will result in 
-			// a download/upload on the next sync, which is safer than keeping inconsistent state.
-			const hasLocal = fileState.localMtime !== undefined;
-			const hasRemote = fileState.remoteMtime !== undefined;
-			
-			// Only include entries that have both timestamps or neither (complete states)
-			if ((hasLocal && hasRemote) || (!hasLocal && !hasRemote)) {
-				// Skip entries with neither timestamp (obsolete)
-				if (hasLocal || hasRemote) {
-					newState[filePath] = fileState;
-				}
+			// Include entries that have at least one timestamp
+			if (fileState.localMtime !== undefined || fileState.remoteMtime !== undefined) {
+				newState[filePath] = fileState;
 			}
-			// Incomplete entries (only localMtime or only remoteMtime) are filtered out
 		}
 
 		// Save the updated state


### PR DESCRIPTION
This PR fixes a bug where deleted files were being resurrected on the next sync.

### Changes:
- ****: Removed aggressive filtering that discarded state entries with only one timestamp. These entries are necessary to remember that a file was deleted on one side.
- ****: Updated to clear both  and  when a deletion is successful, ensuring the file is properly removed from the state.

Verified with a reproduction test case (now removed).